### PR TITLE
2.0.0 fix achievements

### DIFF
--- a/docs/changelogs/FW-v2.0.0.md
+++ b/docs/changelogs/FW-v2.0.0.md
@@ -301,6 +301,19 @@ Wizard
 
 ## Map Updates
 
+Caverns
+
+- Fixed respawn locations.
+
+Forest
+
+- Fixed mobs from spawning.
+
+Lazarus
+
+- Extended seaside cliff near the beacon.
+- Added an explorable temple at the top of the middle of the map.
+
 Lobby
 
 - Added birch trees.
@@ -312,14 +325,9 @@ Oasis
 - Added signs to help guide players to the beacon.
 - Added ice to the tunnels underneath the beacon.
 
-Lazarus
+River
 
-- Extended seaside cliff near the beacon.
-- Added an explorable temple at the top of the middle of the map.
-
-Forest
-
-- Fixed mobs from spawning.
+- Fixed beacons not showing their beam upon loading the map.
 
 Urban
 

--- a/docs/kits/Bomber.md
+++ b/docs/kits/Bomber.md
@@ -73,12 +73,12 @@ Bombs will disable shields if the bomb hits a player that is blocking.
 <!-- prettier-ignore -->
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
-| Aye, what just happened? | Blow up an enemy from far away. | 20 Credits |
-| Couldn't ya see the bloody bombs! | Blow up a invisible enemy. | 20 Credits |
+| Aye, what just happened? | Blow up an enemy from far away as bomber. | 20 Credits |
+| Couldn't ya see the bloody bombs! | Blow up a invisible enemy as bomber. | 20 Credits |
 | The Destruction of Fort Knox! | Blow up enemy builder bricks as bomber! | 20 Credits |
-| Ka-boooom! | Get a double bomb kill. | 30 Credits |
-| Kablooie! | Get a triple bomb kill. | 50 Credits |
-| And that's what ya get for touching that! | Get 1,000 bomb kills. | 250 Credits |
+| Ka-boooom! | Get a double bomb kill as bomber. | 30 Credits |
+| Kablooie! | Get a triple bomb kill as bomber. | 50 Credits |
+| And that's what ya get for touching that! | Get 1,000 bomb kills as bomber. | 250 Credits |
 
 <br />
 

--- a/docs/kits/Builder.md
+++ b/docs/kits/Builder.md
@@ -89,7 +89,7 @@ Receive bricks and ladders from engineer dispensers.
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
 | BUILDAH KILL! | Eliminate an enemy with your bricks. | 20 Credits |
-| Don't underestimate the BRICKS! | Get an environmental kill as builder. | 20 Credits |
+| Don't underestimate the BRICKS! | Get a death plane kill as builder. | 20 Credits |
 | Monumental Mason | Get 1,000 brick kills. | 250 Credits |
 | Ladder to heaven! | Place 25,000 ladders. | 1,000 Credits |
 | Sturdy fortress! | Place 100,000 bricks. | 1,000 Credits |

--- a/docs/kits/Crusher.md
+++ b/docs/kits/Crusher.md
@@ -71,7 +71,7 @@ Anvils will damage engineer blocks.
 | Anvil Inc. | Hit 1,000 enemies with summoned anvils. | 50 Credits |
 | Splat! | Get a double anvil kill! | 50 Credits |
 | Blacksmith's Graveyard | Get a triple anvil kill! | 50 Credits |
-| “Kilogramme o' steel” | Get 1000 anvil kills! | 250 Credits |
+| “Kilogramme o' steel” | Get 1,000 anvil kills! | 250 Credits |
 
 <br />
 

--- a/docs/kits/Crusher.md
+++ b/docs/kits/Crusher.md
@@ -65,7 +65,7 @@ Anvils will damage engineer blocks.
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
 | Bird Squ-”watcher” | Summon an anvil mid-air above a raven to bring them down and crush them. | 20 Credits |
-| Bowling Ball vs Trampoline! | Kill a slime with an anvil. | 20 Credits |
+| Bowling Ball vs Trampoline! | Kill a slime minion with an anvil. | 20 Credits |
 | Heavy Metal | Get a direct anvil kill. | 20 Credits |
 | Pixar Lamp | Crush an engineer sentry and destroy it. | 20 Credits |
 | Anvil Inc. | Hit 1,000 enemies with summoned anvils. | 50 Credits |

--- a/docs/kits/Demolitionist.md
+++ b/docs/kits/Demolitionist.md
@@ -94,7 +94,7 @@ When the player is close to a friendly [Bomber](./Bomber.md), and the friendly B
 | Bombs, Blocks, and Bones | Get a triple bomb kill as a demolitionist. | 50 Credits |
 | Where did they go? Are they in the walls? | Get a quadruple bomb kill as a demolitionist. | 50 Credits |
 | Base Breaker | Destroy 100,000 blocks with your bomb. | 250 Credits |
-| Ultimate Demolisher | Get 1000 bomb kills as a demolitionist. | 250 Credits |
+| Ultimate Demolisher | Get 1,000 bomb kills as a demolitionist. | 250 Credits |
 
 <br />
 

--- a/docs/kits/Engineer.md
+++ b/docs/kits/Engineer.md
@@ -171,7 +171,7 @@ Obtain `{{ kits.engineer.data.ENGINEER_KILL_ELIMINATION_REWARD }}` metal after a
 | Howdy, pardner! | Stun an enemy sentry! | 20 Credits |
 | Land Grab! | Help a teammate repair one of their buildings. | 20 Credits |
 | The engineer is Engi-here! | As engineer, take your teleporter that leads right into the enemy base. | 20 Credits |
-| Drugstore Cowboy | Dispense a combined amount of over 10,000 health pots. | 250 Credits |
+| Drugstore Cowboy | Dispense a combined amount of over 10,000 health potions. | 250 Credits |
 | Best Little Slaughterhouse in Texas | Rack up over 5,000 kills with your sentry gun. | 1,000 Credits |
 
 <br />

--- a/docs/kits/Illusionist.md
+++ b/docs/kits/Illusionist.md
@@ -91,7 +91,7 @@ If the player damages an enemy to uncloak, they will also hack them for `{{ kits
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
 | Haha...your plan Z failed! | Kill an illusionist while they are invisible. | 20 Credits |
-| I murdered your toys as well. | Hack an enemy sentry! | 20 Credits |
+| I murdered your toys as well. | Hack an enemy sentry as illusionist. | 20 Credits |
 | Plan Z is working perfectly! | Fake your death as illusionist and kill the opponent that you faked your death against. | 20 Credits |
 | Plan Z, I love ya! | Fake your death as illusionist. | 20 Credits |
 | Pure Divination | Get 1,000 future sight kills. | 250 Credits |

--- a/docs/kits/Medic.md
+++ b/docs/kits/Medic.md
@@ -82,7 +82,7 @@ Electrolytes are used by the [Healing Stone](#healing-stone) ability to heal all
 <!-- prettier-ignore -->
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
-| Get zem. Raus, Raus! | Heal 4 allies at once. | 20 Credits |
+| Get zem. Raus, Raus! | Heal 4 allies at once as medic. | 20 Credits |
 | Ze healing is not as revarding as ze hurting! | Do a total of 100,000 healing as medic. | 250 Credits |
 
 <br />

--- a/docs/kits/Mercy.md
+++ b/docs/kits/Mercy.md
@@ -101,7 +101,7 @@ Right-click or left-click to cycle the `Staff` between `Health Mode` and `Damage
 | ----------- | ----------- | ------ |
 | Fine, I'll do it myself... | Attach a mercy beam to yourself as mercy. | 20 Credits |
 | You might not want to tell your friends about that. | Get a final blow as mercy | 20 Credits |
-| Midwife Crisis | As mercy, heal an Engineer as he repairs his sentry gun. | 20 Credits |
+| Midwife Crisis | As mercy, have your beam attached to a friendly engineer as they repair their sentry gun. | 20 Credits |
 | Battle Mercy | Get 1,000 kills as Mercy. | 250 Credits |
 
 <br />

--- a/docs/kits/Porcupine.md
+++ b/docs/kits/Porcupine.md
@@ -71,7 +71,7 @@ After using the quills ability, the player will receive the thorns effect for `{
 | ----------- | ----------- | ------ |
 | Effective Quills | Get a double quill kill. | 20 Credits |
 | Super Effective Quills | Get a triple quill kill. | 20 Credits |
-| Did that hurt? | Get a kill with your thorns. | 20 Credits |
+| Did that hurt? | Get a kill with your thorns as porcupine. | 20 Credits |
 | Spiny | Get 1,000 quill kills. | 250 Credits |
 
 <br />

--- a/docs/kits/Potion_Master.md
+++ b/docs/kits/Potion_Master.md
@@ -89,7 +89,7 @@ Affects enemies with Weakness (Level: `{{ kits.potion_master.data.POTION_MASTER_
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
 | Damage? What Damage? | Kill a brute while they are in berserk and have weakness applied. | 20 Credits |
-| Creeper Cocktail | Throw a potion on a creeper as potion master. | 20 Credits |
+| Creeper Cocktail | Throw a potion on an enemy creeper as potion master. | 20 Credits |
 | Two to go please! | Get a double potion kill. | 20 Credits |
 | Superb Cocktail | Get 1,000 potion kills. | 250 Credits |
 

--- a/docs/kits/Potion_Master.md
+++ b/docs/kits/Potion_Master.md
@@ -88,7 +88,7 @@ Affects enemies with Weakness (Level: `{{ kits.potion_master.data.POTION_MASTER_
 <!-- prettier-ignore -->
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
-| Damage? What Damage? | Kill a brute while they are in berserk and have weakness applied. | 20 Credits |
+| Damage? What Damage? | Kill a brute while they are in berserk and have weakness applied as potion master. | 20 Credits |
 | Creeper Cocktail | Throw a potion on an enemy creeper as potion master. | 20 Credits |
 | Two to go please! | Get a double potion kill. | 20 Credits |
 | Superb Cocktail | Get 1,000 potion kills. | 250 Credits |

--- a/docs/kits/Slime.md
+++ b/docs/kits/Slime.md
@@ -88,7 +88,7 @@ When a slime minion dies and the player is within `{{ kits.slime.data.SLIME_MINI
 | Extra protection. | Provide a kangaroo with slime armor! | 20 Credits |
 | Not just a damage sponge! | Get a slime kill. | 20 Credits |
 | Slimy slime | Provide slime armor to your slimes. | 20 Credits |
-| Damage Sponge | Mitigate 10,000 damage from allies. | 250 Credits |
+| Damage Sponge | Mitigate 10,000 damage from allies as slime. | 250 Credits |
 | Optimus Slime | Get 1,000 slime kills. | 250 Credits |
 
 <br />

--- a/docs/kits/Vitalist.md
+++ b/docs/kits/Vitalist.md
@@ -114,10 +114,10 @@ Friendly engineer dispensers dispense `{{ kits.vitalist.data.VITALIST_CROSSBOW_A
 <!-- prettier-ignore -->
 | Achievement | Description | Reward |
 | ----------- | ----------- | ------ |
-| Crusader² | Heal a Crusader | 20 Credits |
-| Value from a Distance | Heal a teammate from over 100 blocks away | 20 Credits |
-| Blessed Rebuttal | Get 1,000 kills with the crossbow | 250 Credits |
-| Unbending Support | Heal 100,000 health with crossbow shots | 250 Credits |
+| Crusader² | Heal a crusader as vitalist | 20 Credits |
+| Value from a Distance | Heal a teammate from over 100 blocks away as vitalist | 20 Credits |
+| Blessed Rebuttal | Get 1,000 kills with the crossbow as vitalist | 250 Credits |
+| Unbending Support | Heal 100,000 health with crossbow shots as vitalist | 250 Credits |
 
 <br />
 


### PR DESCRIPTION
Fixed kit achievements that were broken after the kit reimplementation.

KITS_CRUSHER_CRUSH_SENTRY
KITS_ENGINEER_STUN_SENTRY
KITS_GUNNER_SHIELD_BULLET
KITS_GUNNER_SENTRY_VS_MACHINE_GUN
KITS_HULK_3_RAGE_KILLS
KITS_HULK_HULK_SMASH
KITS_ILLUSIONIST_HACK_SENTRY
KITS_ILLUSIONIST_KILL_WHILE_INVIS
KITS_KANGAROO_STOMP_DESTROY_SENTRY
KITS_KANGAROO_STOMP_AND_HIT_FROM_50_BLOCKS
KITS_MERCY_ENGINEER
KITS_MUSKETEER_SENTRY_75_BLOCKS_AWAY
KITS_MUSKETEER_KILL_WHILE_RELOADING
KITS_POTION_MASTER_KILL_BRUTE_IN_BERSERK_WITH_WEAKNESS
KITS_POTION_MASTER_DOUBLE_POTION_KILL
KITS_POTION_MASTER_1000_POTION_KILLS
KITS_PYROTECHNIC_ROCKET_RAVEN_OUT_OF_FLIGHT
KITS_SOLDIER_GRENADE_DESTROY_SENTRY
KITS_SOLDIER_DESTROY_BUILDER_BRICKS
KITS_WIZARD_CHAIN_LIGHTNING_HIT_ENEMY_AND_ENGINEER_BLOCK