### PR TITLE
2.1.1 general enhancements - 1/2

### DIFF
--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -2,9 +2,15 @@ _Release Date: 8/04/2025_
 
 # v2.1.1
 
+## General Changes
+
+- Allow players to leave a team at any point in the lobby.
+- Improve the leaving and joining team logic.
+
 ## Bug Fixes
 
 - Fixed the issue where players could get stuck while joining a game while the game is loading.
 - Fixed admins losing flight if relogging during build phase.
 - Fixed issue where wind charges broke blocks.
 - Fixed issue where players could get their kit gear early if they relogged during build phase and selected a new kit.
+- Fixed issue where players leaving while in the lobby wouldn't properly remove the player from the miencraft team.

--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -7,3 +7,4 @@ _Release Date: 8/04/2025_
 - Fixed the issue where players could get stuck while joining a game while the game is loading.
 - Fixed admins losing flight if relogging during build phase.
 - Fixed issue where wind charges broke blocks.
+- Fixed issue where players could get their kit gear early if they relogged during build phase and selected a new kit.

--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -7,6 +7,8 @@ _Release Date: 8/04/2025_
 - Allow players to leave a team at any point in the lobby.
 - Improve the leaving and joining team logic.
 - The gamerule voting menu now opens automatically when gamerule voting starts for players that are on a team, haven't voted, and aren't in a parkour session.
+- Added a new "Retired" rank. Displayed as "R".
+- Updated the "Veteran" rank to display as "OG".
 
 ## Bug Fixes
 

--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -1,3 +1,7 @@
 _Release Date: 8/04/2025_
 
 # v2.1.1
+
+## Bug Fixes
+
+- Fixed the issue where players could get stuck while joining a game while the game is loading.

--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -5,3 +5,4 @@ _Release Date: 8/04/2025_
 ## Bug Fixes
 
 - Fixed the issue where players could get stuck while joining a game while the game is loading.
+- Fixed admins losing flight if relogging during build phase.

--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -6,6 +6,7 @@ _Release Date: 8/04/2025_
 
 - Allow players to leave a team at any point in the lobby.
 - Improve the leaving and joining team logic.
+- The gamerule voting menu now opens automatically when gamerule voting starts for players that are on a team, haven't voted, and aren't in a parkour session.
 
 ## Bug Fixes
 

--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -14,3 +14,4 @@ _Release Date: 8/04/2025_
 - Fixed issue where wind charges broke blocks.
 - Fixed issue where players could get their kit gear early if they relogged during build phase and selected a new kit.
 - Fixed issue where players leaving while in the lobby wouldn't properly remove the player from the miencraft team.
+- Fixed kit ninja's leaderboard line for total wins.

--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -6,3 +6,4 @@ _Release Date: 8/04/2025_
 
 - Fixed the issue where players could get stuck while joining a game while the game is loading.
 - Fixed admins losing flight if relogging during build phase.
+- Fixed issue where wind charges broke blocks.


### PR DESCRIPTION
## Changes

- Open gamerule voting menu automatically when gamerule voting starts
- Open map voting menu automatically when joining a team
- Open kit selection menu automatically when game is starting
- Add preference for disabling automatically opening menus.

- Updated the Veteran rank short tag to be "OG" instead of "V" and changed the color from dark purple to gold
- Added a new Retired rank

## Bug Fixes

- Necromancer follow owner speed doesn't work #632

## PRs

https://github.com/Fortress-Wars/FortressWars-Wiki/pull/79
https://github.com/Fortress-Wars/FortressWars-Plugin/pull/633

