### PR TITLE
2.1.1 disallow kit switching while in combat 2-3

### DIFF
--- a/docs/changelogs/v2.1.1.md
+++ b/docs/changelogs/v2.1.1.md
@@ -9,6 +9,7 @@ _Release Date: 8/04/2025_
 - The gamerule voting menu now opens automatically when gamerule voting starts for players that are on a team, haven't voted, and aren't in a parkour session.
 - Added a new "Retired" rank. Displayed as "R".
 - Updated the "Veteran" rank to display as "OG".
+- Disallow kit swithcing while in combat.
 
 ## Bug Fixes
 


### PR DESCRIPTION
disallow player from switching kits while in combat with a bollian toggle is settings.yml


https://github.com/Fortress-Wars/FortressWars-Server/pull/35
https://github.com/Fortress-Wars/FortressWars-Wiki/pull/80
https://github.com/Fortress-Wars/FortressWars-Plugin/pull/639